### PR TITLE
Fix for the issue #34 The component 'alvex-orgchart-sync-bootstrap' belongs to a non-existent module 'orgchart'.

### DIFF
--- a/repo/src/main/amp/config/alfresco/module/orgchart/context/alvex-enterprise-orgchart-context.xml
+++ b/repo/src/main/amp/config/alfresco/module/orgchart/context/alvex-enterprise-orgchart-context.xml
@@ -13,7 +13,7 @@
 	<bean id="alvex-orgchart-sync-bootstrap" 
 				class="org.alfresco.repo.module.ImporterModuleComponent" parent="module.baseComponent">
 		<!-- Module properties -->
-		<property name="moduleId" value="orgchart" />
+		<property name="moduleId" value="${project.groupId}.${project.artifactId}" />
 		<property name="name" value="Alvex orgchart sync scripts" />
 		<property name="description" value="Alvex orgchart sync scripts" />
 		<property name="sinceVersion" value="1.3" />


### PR DESCRIPTION
This pull request fixes the issue #34 